### PR TITLE
Issues/5 ログインユーザを既存の一般ユーザに変更

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -19,19 +19,9 @@ RUN apt update && export DEBIAN_FRONTEND=noninteractive && apt -y install --no-i
 RUN apt update && export DEBIAN_FRONTEND=noninteractive && apt -y install --no-install-recommends dnsutils
 RUN apt update && export DEBIAN_FRONTEND=noninteractive && apt -y install --no-install-recommends tree
 
-# Add user and group.
-ARG USER_NAME="user"
-ARG GROUP_NAME="user"
-ARG PASSWORD="password"
-ARG USER_ID=1000
-ARG GROUP_ID=1000
-RUN groupmod -n ${GROUP_NAME} vscode
-RUN usermod -l ${USER_NAME} -d /home/${USER_NAME} -m -G sudo -a vscode
-RUN echo ${USER_NAME}:${PASSWORD} | chpasswd
-
 # Switch user to non-root.
-USER ${USER_NAME}
-WORKDIR /home/${USER_NAME}/
+USER vscode
+WORKDIR /home/vscode/
 
 # Install python related package.
 RUN python -m pip install --upgrade pip

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
 {
     // # General devcontainer.json properties
     "name": "Python 3",
-    "remoteUser": "silverag",
+    "remoteUser": "vscode",
 
     // # Scenario specific properties
     // ## Image or Dockerfile specific properties
@@ -15,17 +15,15 @@
         "dockerfile": "Dockerfile",
         "args": {
             "IMAGE_VERSION": "0.204.8",
-            "PYTHON_VERSION": "3.10",
-            "USER_NAME": "silverag",
-            "GROUP_NAME": "silverag"
+            "PYTHON_VERSION": "3.10"
         }
     },
-    "workspaceMount": "type=bind,src=${localEnv:HOME}/workspace,dst=/home/silverag/workspace,consistency=delegated",
-    "workspaceFolder": "/home/silverag/workspace/Git/python/dev-container-python",
+    "workspaceMount": "type=bind,src=${localEnv:HOME}/workspace,dst=/home/vscode/workspace,consistency=delegated",
+    "workspaceFolder": "/home/vscode/workspace/Git/python/dev-container-python",
     "mounts": [
-        "type=bind,src=${localEnv:HOME}/.bash_aliases,dst=/home/silverag/.bash_aliases,consistency=delegated",
-        "type=bind,src=${localEnv:HOME}/.gitconfig,dst=/home/silverag/.gitconfig,consistency=delegated",
-        "type=bind,src=${localWorkspaceFolder}/.home_directory/.bash_history,dst=/home/silverag/.bash_history,consistency=delegated"
+        "type=bind,src=${localEnv:HOME}/.bash_aliases,dst=/home/vscode/.bash_aliases,consistency=delegated",
+        "type=bind,src=${localEnv:HOME}/.gitconfig,dst=/home/vscode/.gitconfig,consistency=delegated",
+        "type=bind,src=${localWorkspaceFolder}/.home_directory/.bash_history,dst=/home/vscode/.bash_history,consistency=delegated"
     ],
 
     // ## Docker Compose specific properties


### PR DESCRIPTION
## Issue

- #5

## PR

- #8
  上記Issueを開始した際、既存の一般ユーザではIssueに記載した要件を実現できないと考えた。
  そのため、既存の一般ユーザを、引数に指定した一般ユーザに変更する処理を追加した。
  しかし、動作を改めて確認してみたところ、既存の一般ユーザで実現できることが判明した。
  従って、ログインユーザを既存の一般ユーザに変更した。

## ToDoリスト

<!--
- [ ] やることを一覧化する
-->

- [x] ログインユーザを既存の一般ユーザに変更

## NotToDoリスト

<!--
- やらないことを一覧化する
-->

## テスト

<!--
- [ ] 実施するテストを一覧化する
-->

- [x] コマンドラインを開いた時に既存の一般ユーザ`vscode`でログインしていること
- [x] DevContainer内で`git switch`を実行して、ホスト環境で`git switch`を実行した場合、特定の状況でファイルへのアクセス権限がない旨が表示されること
  - #5 - 詳細

## 備考
