### PR TITLE
Issues/15 VSCodeの拡張機能を移行

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -25,9 +25,9 @@
                 "[python]": {
                     // Editor
                     "editor.codeActionsOnSave": {
-                        "source.organizeImports": true
+                        "source.organizeImports.ruff": true
                     },
-                    "editor.defaultFormatter": "ms-python.black-formatter",
+                    "editor.defaultFormatter": "charliermarsh.ruff",
                     "editor.formatOnPaste": false,
                     "editor.formatOnSave": true,
                     "editor.formatOnType": false
@@ -47,9 +47,9 @@
                 ],
                 "python.analysis.typeCheckingMode": "basic",
 
-                // Extension - Flake8
-                "flake8.path": [
-                    "${workspaceFolder}/.venv/bin/pflake8"
+                // Extension - Ruff
+                "ruff.path": [
+                    "${workspaceFolder}/.venv/bin/ruff"
                 ],
 
                 // Extension - Mypy Type Checker
@@ -60,16 +60,6 @@
                 //     // NOTE mypyのバグでpyproject.tomlが読み込まれない
                 //     "--config-file", "${workspaceFolder}/pyproject.toml"
                 // ],
-
-                // Extension - isort
-                "isort.path": [
-                    "${workspaceFolder}/.venv/bin/isort"
-                ],
-
-                // Extension - Black Formatter
-                "black-formatter.path": [
-                    "${workspaceFolder}/.venv/bin/black"
-                ],
 
                 // Extension - VS Code Counter
                 "VSCodeCounter.exclude": [
@@ -93,10 +83,8 @@
 
                 // Programming language related
                 "leojhonsong.python-extension-pack",        // Python Extension Pack
-                "ms-python.flake8",                         // Flake8
-                "ms-python.mypy-type-checker",              // Mypy Type Checker
-                "ms-python.isort",                          // isort
-                "ms-python.black-formatter"                 // Black Formatter
+                "charliermarsh.ruff",                       // Ruff
+                "ms-python.mypy-type-checker"               // Mypy Type Checker
             ]
         }
     }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -33,7 +33,7 @@
                     "editor.formatOnType": false
                 },
 
-                // Extension - Python (Python Extension Pack)
+                // Extension - Python (Python Extension Pack YC)
                 "python.autoComplete.extraPaths": [
                     "${workspaceFolder}/.venv/lib/python3.10/site-packages"
                 ],
@@ -41,7 +41,7 @@
                 "python.terminal.activateEnvironment": false,
                 "python.venvPath": "${workspaceFolder}/.venv",
 
-                // Extension - Pylance (Python Extension Pack)
+                // Extension - Pylance (Python Extension Pack YC)
                 "python.analysis.extraPaths": [
                     "${workspaceFolder}/.venv/lib/python3.10/site-packages"
                 ],
@@ -77,14 +77,10 @@
             "extensions": [
                 // Common
                 "VisualStudioExptTeam.vscodeintellicode",   // Visual Studio IntelliCode
-                "EditorConfig.EditorConfig",                // EditorConfig for Visual Studio Code
-                "be5invis.toml",                            // TOML Language Support
                 "uctakeoff.vscode-counter",                 // VS Code Counter
 
                 // Programming language related
-                "leojhonsong.python-extension-pack",        // Python Extension Pack
-                "charliermarsh.ruff",                       // Ruff
-                "ms-python.mypy-type-checker"               // Mypy Type Checker
+                "yuchenrcheng.vscode-python-pack-yc"        // Python Extension Pack YC
             ]
         }
     }


### PR DESCRIPTION
## Issue

- #15

## PR

## ToDoリスト

<!--
- [ ] やることを一覧化する
-->

- VSCodeの拡張機能を移行
  - [x] ms-python.flake8 => charliermarsh.ruff
  - [x] ms-python.isort => charliermarsh.ruff
  - [x] ms-python.black => charliermarsh.ruff

## NotToDoリスト

<!--
- やらないことを一覧化する
-->

## テスト

<!--
- [ ] 実施するテストを一覧化する
-->

- 静的コード解析ツール
  - リンタ
    - エディタにて設定ファイル(`pyproject.toml`)に従ってエラーが発生すること
      - [x] ruff
      - [ ] mypy
        - mypy本体のバグ(デフォルト値を用いてmypyが実行される)を下記PRで確認しているため、本PRではテスト対象としない
        - #13
    - エディタにてエラーが発生しないこと
      - [x] flake8
        - 拡張機能 Flake8 を使用しない方針にも関わらず、拡張パック Python が当該拡張機能を含んでいる
        - そのため、VSCodeがリンタとして Flake8 を実行してしまう
        - 従って、当該拡張パックを使用しない方針とする
  - フォーマッタ
    - エディタにて設定ファイル(`pyproject.toml`)に従ってフォーマットされること
      - [x] ruff
    - エディタにてフォーマットされないこと
      - [x] isort
      - [x] black

## 備考
